### PR TITLE
[🐛 fix] 이미지 업로드 오류 수정

### DIFF
--- a/src/main/java/org/beep/sbpp/admin/notice/entity/NoticeImage.java
+++ b/src/main/java/org/beep/sbpp/admin/notice/entity/NoticeImage.java
@@ -20,7 +20,7 @@ import lombok.Builder;
  * 공지사항 이미지 엔티티
  */
 @Entity
-@Table(name = "notice_img")
+@Table(name = "tbl_notice_img")
 @Getter
 @Setter
 @NoArgsConstructor


### PR DESCRIPTION
- 글 수정 시 기존에 첨부한 이미지 삭제할 수 있도록 수정
- notice_img 테이블 대신 tbl_notice_img 사용
* feature/notice 브랜치 대신 feature/products에서 작업